### PR TITLE
extra check to ensure variable is well formed

### DIFF
--- a/TdlpackBackend.py
+++ b/TdlpackBackend.py
@@ -508,6 +508,10 @@ def make_variables(index, name_scheme, filters, f):
 
         dims = [k for k in ordered_meta if c[k] is not None]
 
+        for dim in dims:
+            if frame[dim].value_counts().nunique() > 1:
+                raise ValueError(f'un-even numer of records associated with dimension: {dim}\n unique values for {dim}: {frame[dim].unique()} ')
+
         frame = frame.sort_values(dims)
         frame = frame.set_index(dims)
 


### PR DESCRIPTION
It was possible to have a sequence of records for a single variable that were not well formed and get a dataset that appeared well formed. The non-well formed records underneath lead to incorrect data loading.

This check is taken from the grib2io backend